### PR TITLE
Sport box score scraper

### DIFF
--- a/src/models/game.py
+++ b/src/models/game.py
@@ -7,15 +7,17 @@ class Game:
     A model representing a game.
 
     Attributes:
-        - `city`        The city of the game.
-        - `date`        The date of the game.
-        - `gender`      The gender of the game.
-        - `location`    The location of the game. (optional)
-        - `opponent_id` The id of the opposing team.
-        - `result`      The result of the game. (optional)
-        - `sport`       The sport of the game.
-        - `state`       The state of the game.
-        - `time`        The time of the game. (optional)
+        - `city`            The city of the game.
+        - `date`            The date of the game.
+        - `gender`          The gender of the game.
+        - `location`        The location of the game. (optional)
+        - `opponent_id`     The id of the opposing team.
+        - `result`          The result of the game. (optional)
+        - `sport`           The sport of the game.
+        - `state`           The state of the game.
+        - `time`            The time of the game. (optional)
+        - `box_score`       The scoring summary of the game (optional)
+        - `score_breakdown` The scoring breakdown of the game (optional)
     """
 
     def __init__(
@@ -30,6 +32,8 @@ class Game:
         location=None,
         result=None,
         time=None,
+        box_score=None,
+        score_breakdown=None
     ):
         self.id = id if id else str(ObjectId())
         self.city = city
@@ -41,6 +45,8 @@ class Game:
         self.sport = sport
         self.state = state
         self.time = time
+        self.box_score = box_score
+        self.score_breakdown = score_breakdown
 
     def to_dict(self):
         """
@@ -57,6 +63,8 @@ class Game:
             "sport": self.sport,
             "state": self.state,
             "time": self.time,
+            "box_score": self.box_score,
+            "score_breakdown": self.score_breakdown
         }
 
     @staticmethod
@@ -75,4 +83,6 @@ class Game:
             sport=data.get("sport"),
             state=data.get("state"),
             time=data.get("time"),
+            box_score=data.get("box_score"),
+            score_breakdown=data.get("score_breakdown")
         )

--- a/src/mutations/create_game.py
+++ b/src/mutations/create_game.py
@@ -14,6 +14,8 @@ class CreateGame(Mutation):
         sport = String(required=True)
         state = String(required=True)
         time = String(required=True)
+        box_score = String(required=False)
+        score_breakdown = String(required=False)
 
     game = Field(lambda: GameType)
 
@@ -29,6 +31,8 @@ class CreateGame(Mutation):
         location=None,
         result=None,
         time=None,
+        box_score=None,
+        score_breakdown=None
     ):
         game_data = {
             "city": city,
@@ -40,6 +44,8 @@ class CreateGame(Mutation):
             "sport": sport,
             "state": state,
             "time": time,
+            "box_score": box_score,
+            "score_breakdown": score_breakdown
         }
         new_game = GameService.create_game(game_data)
         return CreateGame(game=new_game)

--- a/src/scrapers/game_details_scrape.py
+++ b/src/scrapers/game_details_scrape.py
@@ -1,0 +1,188 @@
+import requests
+from bs4 import BeautifulSoup
+from src.utils.constants import *
+
+def fetch_page(url):
+    response = requests.get(url)
+    return BeautifulSoup(response.text, 'html.parser')
+
+def extract_teams_and_scores(box_score_section, sport):
+    score_table = box_score_section.find(TAG_TABLE, class_=CLASS_SIDEARM_TABLE)
+    team_names = []
+    period_scores = []
+
+    for row in score_table.find(TAG_TBODY).find_all(TAG_TR):
+        team_name_cell = row.find(TAG_TH) if sport == 'ice hockey' else row.find(TAG_TD)
+        if team_name_cell:
+            team_name = team_name_cell.text.strip().replace("Winner", "").strip()
+            team_name = ' '.join(team_name.split())
+        else:
+            team_name = "Unknown"
+        
+        team_names.append(team_name)
+        scores = [td.text.strip() for td in row.find_all(TAG_TD)[1:]]
+        scores = scores[:-1] if sport == 'basketball' else scores
+        period_scores.append(scores)
+
+    return team_names, period_scores
+
+def soccer_summary(box_score_section):
+    summary = []
+    scoring_section = box_score_section.find(TAG_SECTION, {ATTR_ARIA_LABEL: LABEL_SCORING_SUMMARY})
+    if scoring_section:
+        scoring_rows = scoring_section.find(TAG_TBODY)
+        if scoring_rows:
+            for row in scoring_rows.find_all(TAG_TR):
+                time = row.find_all(TAG_TD)[0].text.strip()
+                team = row.find_all(TAG_TD)[1].find(TAG_IMG)[ATTR_ALT]
+                event = row.find_all(TAG_TD)[2]
+                desc = event.find_all(TAG_SPAN)[-1].text.strip()
+                summary.append({'time': time, 'team': team, 'description': desc})
+    if not summary:
+        summary = [{"message": "No scoring events in this game."}]
+    return summary
+
+def football_summary(box_score_section):
+    summary = []
+    scoring_section = box_score_section.find(TAG_SECTION, {ATTR_ARIA_LABEL: LABEL_SCORING_SUMMARY})
+    if scoring_section:
+        scoring_rows = scoring_section.find(TAG_TBODY)
+        if scoring_rows:
+            for row in scoring_rows.find_all(TAG_TR):
+                period = row.find_all(TAG_TD)[1].text.strip()
+                time = row.find_all(TAG_TD)[0].text.strip()
+                description = row.find_all(TAG_TD)[3].text.strip()
+                cornell_score = row.find_all(TAG_TD)[4].text.strip()
+                opp_score = row.find_all(TAG_TD)[5].text.strip()
+                summary.append({
+                    'period': period,
+                    'time': time,
+                    'description': description,
+                    'cor_score': cornell_score,
+                    'opp_score': opp_score
+                })
+    if not summary:
+        summary = [{"message": "No scoring events in this game."}]
+    return summary
+
+def hockey_summary(box_score_section):
+    summary = []
+    scoring_table = box_score_section.find(TAG_TABLE, class_=CLASS_SCORING_SUMMARY)
+    if scoring_table:
+        scoring_rows = scoring_table.find(TAG_TBODY)
+        if scoring_rows:
+            for row in scoring_rows.find_all(TAG_TR):
+                team = row.find_all(TAG_TD)[1].find(TAG_IMG)[ATTR_ALT]
+                period = row.find_all(TAG_TD)[2].text.strip()
+                time = row.find_all(TAG_TD)[3].text.strip()
+                scorer = row.find_all(TAG_TD)[4].text.strip()
+                assist = row.find_all(TAG_TD)[5].text.strip()
+                opp_score = row.find_all(TAG_TD)[6].text.strip()
+                cor_score = row.find_all(TAG_TD)[7].text.strip()
+                summary.append({
+                    'team': team,
+                    'period': period,
+                    'time': time,
+                    'scorer': scorer,
+                    'assist': assist,
+                    'cor_score': cor_score,
+                    'opp_score': opp_score,
+                })
+    if not summary:
+        summary = [{"message": "No scoring events in this game."}]
+    return summary
+
+def field_hockey_summary(box_score_section):
+    summary = []
+    scoring_rows = box_score_section.find(TAG_TABLE, class_=CLASS_OVERALL_STATS).find(TAG_TBODY)
+    if scoring_rows:
+        for row in scoring_rows.find_all(TAG_TR):
+            time = row.find_all(TAG_TD)[0].text.strip()
+            team = row.find_all(TAG_TD)[1].find(TAG_IMG)[ATTR_ALT]
+            event = row.find_all(TAG_TD)[2]
+            desc = event.find_all(TAG_SPAN)[-1].text.strip()
+            summary.append({
+                'time': time,
+                'team': team,
+                'description': desc
+            })
+    if not summary:
+        summary = [{"message": "No scoring events in this game."}]
+    return summary
+
+def lacrosse_summary(box_score_section):
+    summary = []
+    scoring_table = box_score_section.find(TAG_TABLE, class_=CLASS_SCORING_SUMMARY)
+    if scoring_table:
+        scoring_rows = scoring_table.find(TAG_TBODY)
+        if scoring_rows:
+            for row in scoring_rows.find_all(TAG_TR):
+                period = row.find_all(TAG_TD)[2].text.strip()
+                time = row.find_all(TAG_TD)[3].text.strip()
+                scorer = row.find_all(TAG_TD)[4].text.strip()
+                assist = row.find_all(TAG_TD)[5].text.strip()
+                opp_score = row.find_all(TAG_TD)[6].text.strip()
+                cor_score = row.find_all(TAG_TD)[7].text.strip()
+                summary.append({
+                    'period': period,
+                    'time': time,
+                    'scorer': scorer,
+                    'assist': assist,
+                    'cor_score': cor_score,
+                    'opp_score': opp_score,
+                })
+    if not summary:
+        summary = [{"message": "No scoring events in this game."}]
+    return summary
+
+def baseball_summary(box_score_section):
+    summary = []
+    scoring_rows = box_score_section.find(TAG_TABLE, class_=CLASS_SIDEARM_TABLE + " " + CLASS_SCORING_SUMMARY)
+    if scoring_rows:
+        scoring_rows = scoring_rows.find(TAG_TBODY)
+        if scoring_rows:
+            for row in scoring_rows.find_all(TAG_TR):
+                team = row.find_all(TAG_TD)[1].text.strip()
+                period = row.find_all(TAG_TD)[3].text.strip()
+                desc_td = row.find_all(TAG_TD)[4]
+                desc = ''.join(desc_td.find_all(text=True, recursive=False)).strip()
+                cor_score = row.find_all(TAG_TD)[5].text.strip()
+                opp_score = row.find_all(TAG_TD)[6].text.strip()
+                summary.append({
+                    'team': team,
+                    'period': period,
+                    'description': desc,
+                    'cor_score': cor_score,
+                    'opp_score': opp_score
+                })
+    if not summary:
+        summary = [{"message": "No scoring events in this game."}]
+    return summary
+
+def scrape_game(url, sport):
+    soup = fetch_page(url)
+    box_score_section = soup.find(class_=CLASS_BOX_SCORE) if sport in ['baseball', 'softball'] else soup.find(id=ID_BOX_SCORE)
+    if not box_score_section:
+        return {"error": "Box score section not found"}
+    
+    sport_parsers = {
+        'soccer': (lambda: extract_teams_and_scores(box_score_section, 'soccer'), soccer_summary),
+        'football': (lambda: extract_teams_and_scores(box_score_section, 'football'), football_summary),
+        'ice hockey': (lambda: extract_teams_and_scores(box_score_section, 'ice hockey'), hockey_summary),
+        'field hockey': (lambda: extract_teams_and_scores(box_score_section, 'field hockey'), field_hockey_summary),
+        'lacrosse': (lambda: extract_teams_and_scores(box_score_section, 'lacrosse'), lacrosse_summary),
+        'baseball': (lambda: extract_teams_and_scores(box_score_section, 'baseball'), baseball_summary),
+    }
+
+    extract_teams_func, summary_func = sport_parsers.get(sport, (None, None))
+    
+    if extract_teams_func and summary_func:
+        team_names, scores = extract_teams_func()
+        scoring_summary = summary_func(box_score_section)
+        return {
+            'teams': team_names,
+            'scores': scores,
+            'scoring_summary': scoring_summary or [{"message": "No scoring events in this game."}]
+        }
+    
+    return {"error": "Sport parser not found"}

--- a/src/types.py
+++ b/src/types.py
@@ -1,5 +1,4 @@
-from graphene import ObjectType, String
-
+from graphene import ObjectType, String, List, Int
 
 class TeamType(ObjectType):
     """
@@ -21,6 +20,53 @@ class TeamType(ObjectType):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
+class ScoringSummaryType(ObjectType):
+    """
+    Represents a single scoring summary entry in a game.
+
+    Attributes:
+        - `time`: The time at which the scoring event occurred.
+        - `team`: The name of the team that scored.
+        - `description`: A description of the scoring event.
+    """
+    time = String()
+    team = String()
+    description = String()
+
+class BoxScoreEntryType(ObjectType):
+    """
+    Represents an individual entry in the box score of a game.
+
+    Attributes:
+        - `team`: The team involved in the scoring event.
+        - `period`: The period or inning of the event.
+        - `time`: The time of the scoring event.
+        - `description`: A description of the play or scoring event.
+        - `scorer`: The name of the scorer.
+        - `assist`: The name of the assisting player.
+        - `score_by`: Indicates which team scored.
+        - `cor_score`: Cornell's score at the time of the event.
+        - `opp_score`: Opponent's score at the time of the event.
+    """
+    
+    team = String(required=False)
+    period = String(required=False)
+    time = String(required=False)
+    description = String(required=False)
+    scorer = String(required=False)
+    assist = String(required=False)
+    score_by = String(required=False)
+    cor_score = Int(required=False)
+    opp_score = Int(required=False)
+
+class ScoreBreakdownType(ObjectType):
+    """
+    Represents the score breakdown for each period in a game.
+
+    Attributes:
+        - `scores`: A list of scores for each period of the game.
+    """
+    scores = List(String)
 
 class GameType(ObjectType):
     """
@@ -37,6 +83,8 @@ class GameType(ObjectType):
         - `sport`: The sport of the game.
         - `state`: The state of the game.
         - `time`: The time of the game. (optional)
+        - `box_score`: The box score of the game.
+        - `score_breakdown`: The score breakdown of the game.
     """
 
     id = String(required=False)
@@ -49,9 +97,11 @@ class GameType(ObjectType):
     sport = String(required=True)
     state = String(required=True)
     time = String(required=False)
+    box_score = List(BoxScoreEntryType, required=False)
+    score_breakdown = List(List(String), required=False)
 
     def __init__(
-        self, id, city, date, gender, location, opponent_id, result, sport, state, time
+        self, id, city, date, gender, location, opponent_id, result, sport, state, time, box_score=None, score_breakdown=None
     ):
         self.id = id
         self.city = city
@@ -63,3 +113,5 @@ class GameType(ObjectType):
         self.sport = sport
         self.state = state
         self.time = time
+        self.box_score = box_score
+        self.score_breakdown = score_breakdown

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -1,5 +1,8 @@
 # Prefix for opponent image URLs
-IMAGE_PREFIX = "https://cornellbigred.com"
+IMAGE_PREFIX = "https://dxbhsrqyrr690.cloudfront.net/sidearm.nextgen.sites/cornellbigred.com"
+
+# Base URL
+BASE_URL = "https://cornellbigred.com"
 
 # The tag for each game
 GAME_TAG = ".sidearm-schedule-game"
@@ -33,6 +36,47 @@ SCHEDULE_POSTFIX = "/schedule"
 
 # The tag for each result
 RESULT_TAG = ".sidearm-schedule-game-result"
+
+# The tag for the box score
+BOX_SCORE_TAG = ".sidearm-schedule-game-links-boxscore a"
+
+# HTML Tags
+TAG_TABLE = 'table'
+TAG_SECTION = 'section'
+TAG_TBODY = 'tbody'
+TAG_TR = 'tr'
+TAG_TD = 'td'
+TAG_TH = 'th'
+TAG_SPAN = 'span'
+TAG_IMG = 'img'
+
+# HTML Classes
+CLASS_SIDEARM_TABLE = 'sidearm-table'
+CLASS_HIDE_ON_LARGE_DOWN = 'hide-on-large-down'
+CLASS_HIDE_ON_SMALL_DOWN = 'hide-on-small-down'
+CLASS_SCORING_SUMMARY = 'scoring-summary'
+CLASS_OVERALL_STATS = 'overall-stats'
+CLASS_PLAY_BY_PLAY = 'play-by-play'
+CLASS_BOX_SCORE = 'box-score'
+
+# HTML Attributes
+ATTR_ARIA_LABEL = 'aria-label'
+ATTR_ALT = 'alt'
+ATTR_ID = 'id'
+
+# HTML IDs for Sections
+ID_BOX_SCORE = 'box-score'
+ID_PERIOD_1 = 'period-1'
+ID_PERIOD_2 = 'period-2'
+ID_SET_1 = 'set-1'
+ID_SET_2 = 'set-2'
+ID_SET_3 = 'set-3'
+ID_SET_4 = 'set-4'
+ID_SET_5 = 'set-5'
+
+# Labels
+LABEL_SCORING_SUMMARY = 'Scoring Summary'
+LABEL_CU = 'CU'
 
 # The dictionary mapping sports urls to gender
 SPORT_URLS = {


### PR DESCRIPTION
Created the Box Score and Score Breakdown Scraper for Games for All Sports
## Overview
For the games that we are fetching, we need to get data for the game details screen. To do this, I created a game_details_scraper.py file that gets the box scores and scoring breakdowns for all the sports that we play at Cornell. I am adding to games so for games that have happened, we have access to the details of that game like points each quarter, who scored what at what time, etc.


## Changes Made
Added box_score and score_breakdown fields to the GameType and made the corresponding changes to the games_scraper.py file by incorporating the scrape_game function from the game_details_scraper.py


## Test Coverage
I tested this feature using Postman



## Next Steps (delete if not applicable)
Next steps would be creating a live game scraper, that would scrape a sidearm page for a game's details realtime.


## Screenshots
<img width="1003" alt="Screenshot 2024-11-10 at 12 27 27 PM" src="https://github.com/user-attachments/assets/b5c08f39-ae81-4bf3-9c28-dd7eeb895adb">
