### PR TITLE
Add threading to game scraper

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,13 +8,13 @@ from src.schema import Query, Mutation
 from src.scrapers.games_scraper import fetch_game_schedule
 from src.scrapers.youtube_stats import fetch_videos
 from src.utils.team_loader import TeamLoader
+import time
 
 app = Flask(__name__)
 
 # Set up the scheduler
 scheduler = APScheduler()
 scheduler.init_app(app)
-scheduler.start()
 
 # Configure logging
 logging.basicConfig(
@@ -46,11 +46,16 @@ def parse_args():
 
 args = parse_args()
 if not args.no_scrape:
-    @scheduler.task("interval", id="scrape_schedules", seconds=3600)
+    # scrapes games every 5 minutes. 
+    # need testing to see if this can be lower safely
+    @scheduler.task("interval", id="scrape_schedules", seconds=300)
 
     def scrape_schedules():
-        logging.info("Scraping game schedules...")
+        start_time = time.time()
+        logging.info("Starting game schedule scraping...")
         fetch_game_schedule()
+        elapsed_time = time.time() - start_time
+        logging.info(f"Completed game schedule scraping in {elapsed_time:.2f} seconds")
 
     @scheduler.task("interval", id="scrape_schedules", seconds=43200)
     def scrape_videos():

--- a/src/scrapers/games_scraper.py
+++ b/src/scrapers/games_scraper.py
@@ -55,6 +55,7 @@ def fetch_game_schedule():
             args=(url, data["sport"], data["gender"]),
             name=f"Scraper-{sport}"
         )
+        thread.daemon = True
         threads.append(thread)
         thread.start()
     

--- a/src/scrapers/games_scraper.py
+++ b/src/scrapers/games_scraper.py
@@ -57,11 +57,9 @@ def fetch_game_schedule():
         )
         threads.append(thread)
         thread.start()
-        print(f"Started thread for {data['sport']} ({data['gender']})")
     
     for thread in threads:
         thread.join()
-        print(f"Completed thread: {thread.name}")
 
 def parse_schedule_page(url, sport, gender):
     """
@@ -75,9 +73,7 @@ def parse_schedule_page(url, sport, gender):
     soup = BeautifulSoup(response.content, "html.parser")
 
     page_title = soup.title.text.strip() if soup.title else ""
-    print(page_title)
     season_years = extract_season_years(page_title)
-    print(season_years)
 
     for game_item in soup.select(GAME_TAG):
         game_data = {}


### PR DESCRIPTION
## Overview
Added threading to game scraper. Creates one thread per sport.

## Changes Made
Used python threading library to create threads to scrape. Added graceful keyboard interrupt handling. Also lowered interval of scraping to 5 minutes. 

## Test Coverage
Tested locally. Decreased scraping time from ~ 2:08 to ~ 0:50 when testing locally. Will need more testing to see how long scrapes take on dev and if it is safe to lower interval more.