### PR TITLE
Fix incorrect soccer scores

### DIFF
--- a/src/scrapers/game_details_scrape.py
+++ b/src/scrapers/game_details_scrape.py
@@ -40,7 +40,7 @@ def soccer_summary(box_score_section):
                 event = row.find_all(TAG_TD)[2]
                 desc = event.find_all(TAG_SPAN)[-1].text.strip()
                 
-                if team == "COR" or team == "CU":
+                if team == "COR" or team == "CU" or team == "Corn":
                     cornell_score += 1
                 else:
                     opp_score += 1


### PR DESCRIPTION
Added tag "Corn" to soccer scraper which is sometimes used instead of CU or COR.

Tested locally