### PR TITLE
Fix duplicate games

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,14 +102,22 @@ def parse_args():
     )
     return parser.parse_args()
 
-args = parse_args()
-
 def signal_handler(sig, frame):
     sys.exit(0)
 
 
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)
+
+# Only parse arguments when running directly (not when imported by gunicorn)
+if __name__ == "__main__":
+    args = parse_args()
+else:
+    # Default args when imported by gunicorn
+    class DefaultArgs:
+        no_scrape = False
+        no_daily_sun = False
+    args = DefaultArgs()
 
 # Only run scraping tasks if not disabled
 if not args.no_scrape:


### PR DESCRIPTION
### Overview
Fixed logic for fetching games, now games will be fetched without duplication and only updates if there are changes to a game. Additionally, for games that are tournaments that aren't finalized yet, we will update that specific tournament game that is initially fetched by our scrapers and update it with the details. If a team loses, then we would be able to delete games that are scheduled after it (situations like if we lost in the first round, etc.). If normal games have TBD or TBA fields for time and location, they will now be updated accordingly too.

### Changes Made
- Fixed the scraper logic to create unique indices for games, so when we run the scraper again, we don't add the same game again, creating duplicates.
- Resolved issue where updating tournament games from placeholder teams (e.g., "First Round") to real teams would create duplicates
- Implemented flexible tournament game lookup that finds games by location/date rather than opponent_id
Added new database index (sport, gender, date, city, state) to support tournament game queries