### PR TITLE
Added ticket links to game objects

### DIFF
--- a/app.py
+++ b/app.py
@@ -155,4 +155,4 @@ if not args.no_daily_sun and not args.no_scrape:
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host="0.0.0.0", port=8000)
+    app.run(debug=True, host="0.0.0.0", port=8001)

--- a/src/models/game.py
+++ b/src/models/game.py
@@ -17,6 +17,7 @@ class Game:
         - `time`            The time of the game. (optional)
         - `box_score`       The scoring summary of the game (optional)
         - `score_breakdown` The scoring breakdown of the game (optional)
+        - 'ticket_link'    The ticket link for the game (optional)
     """
 
     def __init__(
@@ -35,6 +36,7 @@ class Game:
         score_breakdown=None,
         team=None,
         utc_date=None,
+        ticket_link=None,
     ):
         self.id = id if id else str(ObjectId())
         self.city = city
@@ -50,6 +52,7 @@ class Game:
         self.score_breakdown = score_breakdown
         self.team = team
         self.utc_date = utc_date
+        self.ticket_link = ticket_link
 
     def to_dict(self):
         """
@@ -70,6 +73,7 @@ class Game:
             "score_breakdown": self.score_breakdown,
             "team": self.team,
             "utc_date": self.utc_date,
+            "ticket_link": self.ticket_link,
         }
 
     @staticmethod
@@ -92,4 +96,5 @@ class Game:
             score_breakdown=data.get("score_breakdown"),
             team=data.get("team"),
             utc_date=data.get("utc_date"),
+            ticket_link=data.get("ticket_link"),
         )

--- a/src/mutations/create_game.py
+++ b/src/mutations/create_game.py
@@ -17,6 +17,7 @@ class CreateGame(Mutation):
         box_score = String(required=False)
         score_breakdown = String(required=False)
         utc_date = String(required=False)
+        ticket_link = String(required=False)
 
     game = Field(lambda: GameType)
 
@@ -34,7 +35,8 @@ class CreateGame(Mutation):
         time=None,
         box_score=None,
         score_breakdown=None,
-        utc_date=None
+        utc_date=None,
+        ticket_link=None
     ):
         game_data = {
             "city": city,
@@ -48,7 +50,8 @@ class CreateGame(Mutation):
             "time": time,
             "box_score": box_score,
             "score_breakdown": score_breakdown,
-            "utc_date": utc_date
+            "utc_date": utc_date,
+            "ticket_link": ticket_link
         }
         new_game = GameService.create_game(game_data)
         return CreateGame(game=new_game)

--- a/src/queries/game_query.py
+++ b/src/queries/game_query.py
@@ -20,6 +20,7 @@ class GameQuery(ObjectType):
         sport=String(required=True),
         state=String(required=True),
         time=String(required=True),
+        ticket_link=String(required=False),
     )
     games_by_sport = List(GameType, sport=String(required=True))
     games_by_gender = List(GameType, gender=String(required=True))
@@ -40,13 +41,13 @@ class GameQuery(ObjectType):
         return GameService.get_game_by_id(id)
 
     def resolve_game_by_data(
-        self, info, city, date, gender, opponent_id, sport, state, time, location=None
+        self, info, city, date, gender, opponent_id, sport, state, time, location=None, ticket_link=None
     ):
         """
         Resolver for retrieving a game by its data.
         """
         return GameService.get_game_by_data(
-            city, date, gender, location, opponent_id, sport, state, time
+            city, date, gender, location, opponent_id, sport, state, time, ticket_link
         )
 
     def resolve_games_by_sport(self, info, sport):

--- a/src/scrapers/games_scraper.py
+++ b/src/scrapers/games_scraper.py
@@ -153,7 +153,14 @@ def parse_schedule_page(url, sport, gender):
         else:
             game_data["box_score"] = None
             game_data["score_breakdown"] = None
-
+        
+        ticket_link_tag = game_item.select_one(GAME_TICKET_LINK)
+        ticket_link = (
+        ticket_link_tag["href"] if ticket_link_tag else None
+        )
+        game_data["ticket_link"] = (
+            ticket_link if ticket_link else None
+        )
         process_game_data(game_data)
 
 
@@ -253,7 +260,11 @@ def process_game_data(game_data):
             "result": game_data["result"],
             "box_score": game_data["box_score"],
             "score_breakdown": game_data["score_breakdown"],
-            "utc_date": utc_date_str
+            "utc_date": utc_date_str,
+            "city": city,
+            "location": location,
+            "state": state,
+            "ticket_link": game_data["ticket_link"]
         }
         GameService.update_game(curr_game.id, updates)
         return
@@ -270,7 +281,8 @@ def process_game_data(game_data):
         "time": game_time,
         "box_score": game_data["box_score"],
         "score_breakdown": game_data["score_breakdown"],
-        "utc_date": utc_date_str
+        "utc_date": utc_date_str,
+        "ticket_link": game_data["ticket_link"]
     }
         
     GameService.create_game(game_data)

--- a/src/types.py
+++ b/src/types.py
@@ -88,6 +88,7 @@ class GameType(ObjectType):
         - `time`: The time of the game. (optional)
         - `box_score`: The box score of the game.
         - `score_breakdown`: The score breakdown of the game.
+        - `ticket_link`: The ticket link of the game. (optional)
     """
 
     id = String(required=False)
@@ -104,11 +105,11 @@ class GameType(ObjectType):
     score_breakdown = List(List(String), required=False)
     team = Field(TeamType, required=False)
     utc_date = String(required=False)
-
+    ticket_link = String(required=False)
     def __init__(
-        self, id, city, date, gender, location, opponent_id, result, sport, state, time, box_score=None, score_breakdown=None, utc_date=None
+        self, id, city, date, gender, location, opponent_id, result, sport, state, time, box_score=None, score_breakdown=None, utc_date=None, ticket_link=None
     ):
-        self.id = id
+        self.id = id    
         self.city = city
         self.date = date
         self.gender = gender
@@ -121,7 +122,7 @@ class GameType(ObjectType):
         self.box_score = box_score
         self.score_breakdown = score_breakdown
         self.utc_date = utc_date
-    
+        self.ticket_link = ticket_link
     @staticmethod
     def team_to_team_type(team_obj):
         if team_obj is None:
@@ -138,7 +139,7 @@ class GameType(ObjectType):
         # getting team id - team could be None in older data
         team_id = parent.team if parent.team is not None else parent.opponent_id
         if team_id and isinstance(team_id, str):
-            # promise to get team object once the dataloader is ready
+            # promise to get team object once    the dataloader is ready
             promise = info.context["team_loader"].load(team_id)
             return promise.then(GameType.team_to_team_type)
         return None

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -40,6 +40,9 @@ RESULT_TAG = ".sidearm-schedule-game-result"
 # The tag for the box score
 BOX_SCORE_TAG = ".sidearm-schedule-game-links-boxscore a"
 
+# The tag for the game ticket link
+GAME_TICKET_LINK = ".sidearm-schedule-game-links-tickets a"
+
 # HTML Tags
 TAG_TABLE = 'table'
 TAG_SECTION = 'section'
@@ -126,3 +129,5 @@ CHANNEL_ID = "UClSQOi2gnn9bi7mcgQrAVKA"
 
 # The maximum number of videos to retrieve
 VIDEO_LIMIT = 20
+
+


### PR DESCRIPTION
## Overview

<!-- Summarize your changes here. -->
I created a ticketLink field for the game object that allows ticketed games to store their ticket links in their respective game object. Ticket links will be set to null for non ticketed and past games. 


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
I found the HTML class selector (.sidearm-schedule-game-links-tickets a) that selects for the ticket links and scraped the attribute element for its href and stored that in the ticketLink field. I then updated all the relevant model, mutation files to account for this new field. 



## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
I tested this locally using the GraphQL playground. 


