### PR TITLE
Added Daily Sun Images

### DIFF
--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -130,4 +130,4 @@ CHANNEL_ID = "UClSQOi2gnn9bi7mcgQrAVKA"
 # The maximum number of videos to retrieve
 VIDEO_LIMIT = 20
 
-
+ARTICLE_IMG_TAG = ".dom-art-container img"


### PR DESCRIPTION
## Overview

Using the Daily Sun json, I extracted the slug to build the Cornell Daily Sun URL for the articles. I then scraped for the image src attribute to find the associated image for these articles.


## Changes Made

I deleted previous attempt at extracting the article image from the JSON and replaced it with the web scraping approach. 


## Test Coverage

I tested this locally with the GraphQL playground. 