### PR TITLE
Refactor article date handling to use ISO 8601 format

### DIFF
--- a/src/mutations/create_article.py
+++ b/src/mutations/create_article.py
@@ -14,11 +14,10 @@ class CreateArticle(Mutation):
     article = Field(lambda: ArticleType)
 
     def mutate(self, info, title, sports_type, published_at, url, slug, image=None):
-        from datetime import datetime
         article_data = {
             "title": title,
             "sports_type": sports_type,
-            "published_at": datetime.fromisoformat(published_at),
+            "published_at": published_at,  # Already in ISO 8601 format
             "url": url,
             "slug": slug,
             "image": image

--- a/src/repositories/article_repository.py
+++ b/src/repositories/article_repository.py
@@ -1,7 +1,7 @@
 from src.database import daily_sun_db
 from src.models.article import Article
 from pymongo import UpdateOne
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 class ArticleRepository:
     @staticmethod
@@ -52,7 +52,9 @@ class ArticleRepository:
         Retrieve articles from the last N days, sorted by published_at descending.
         """
         article_collection = daily_sun_db["news_articles"]
-        query = {"published_at": {"$gte": datetime.now() - timedelta(days=limit_days)}}
+        # Calculate threshold as ISO 8601 string
+        threshold = (datetime.now(timezone.utc) - timedelta(days=limit_days)).isoformat().replace('+00:00', 'Z')
+        query = {"published_at": {"$gte": threshold}}
         articles = article_collection.find(query).sort("published_at", -1)
         return [Article.from_dict(article) for article in articles]
 
@@ -62,9 +64,11 @@ class ArticleRepository:
         Retrieve articles by sports_type from the last N days, sorted by published_at descending.
         """
         article_collection = daily_sun_db["news_articles"]
+        # Calculate threshold as ISO 8601 string
+        threshold = (datetime.now(timezone.utc) - timedelta(days=limit_days)).isoformat().replace('+00:00', 'Z')
         query = {
             "sports_type": sports_type,
-            "published_at": {"$gte": datetime.now() - timedelta(days=limit_days)}
+            "published_at": {"$gte": threshold}
         }
         articles = article_collection.find(query).sort("published_at", -1)
         return [Article.from_dict(article) for article in articles]
@@ -75,5 +79,7 @@ class ArticleRepository:
         Delete articles older than N days, sorted by published_at descending.
         """
         article_collection = daily_sun_db["news_articles"]
-        query = {"published_at": {"$lt": datetime.now() - timedelta(days=limit_days)}}
+        # Calculate threshold as ISO 8601 string
+        threshold = (datetime.now(timezone.utc) - timedelta(days=limit_days)).isoformat().replace('+00:00', 'Z')
+        query = {"published_at": {"$lt": threshold}}
         article_collection.delete_many(query)

--- a/src/scrapers/daily_sun_scrape.py
+++ b/src/scrapers/daily_sun_scrape.py
@@ -1,6 +1,6 @@
 import os
 import requests
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
 from ..services import ArticleService
 from ..utils.constants import ARTICLE_IMG_TAG
@@ -23,16 +23,19 @@ def fetch_news():
         response.raise_for_status()
         data = response.json()
 
-        # Current date and 3-day threshold
-        current_date = datetime.now()
+        # Current date and 3-day threshold (in UTC)
+        current_date = datetime.now(timezone.utc)
         three_days_ago = current_date - timedelta(days=3)
 
         # Process articles
         articles_to_store = []
         for article in data.get("articles", []):
-            published_at = datetime.strptime(article["published_at"], "%Y-%m-%d %H:%M:%S")
+            published_at_dt = datetime.strptime(article["published_at"], "%Y-%m-%d %H:%M:%S")
+            # Assume the timezone is UTC and convert to ISO 8601 format string
+            published_at_dt = published_at_dt.replace(tzinfo=timezone.utc)
+            published_at = published_at_dt.isoformat().replace('+00:00', 'Z')
             
-            if published_at >= three_days_ago:
+            if published_at_dt >= three_days_ago:
                 sports_type = next(
                     (tag["name"] for tag in article["tags"] if tag["name"] not in ["Sports", "Top Stories"]),
                     "General"
@@ -61,7 +64,7 @@ def fetch_news():
                     "published_at": published_at,
                     "url": article_url,
                     "slug": article["slug"],
-                    "created_at": datetime.now()
+                    "created_at": datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
                 }
                 articles_to_store.append(article_doc)
              

--- a/src/types.py
+++ b/src/types.py
@@ -190,7 +190,4 @@ class ArticleType(ObjectType):
 
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
-            if key == "published_at" and isinstance(value, datetime):
-                setattr(self, key, value.isoformat())
-            else:
-                setattr(self, key, value)
+            setattr(self, key, value)


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview
Refactor article date handling to use ISO 8601 format


## Changes Made

- Simplified ArticleType initialization by removing datetime conversion for published_at.
- Updated CreateArticle mutation to accept published_at directly in ISO 8601 format.
- Modified ArticleRepository queries to use ISO 8601 strings for date comparisons.
- Adjusted daily_sun_scrape to handle published_at in UTC and convert to ISO 8601 format.



## Test Coverage
Tested locally in GraphQl playground
