### PR TITLE
Added filtering games by location (on/off-campus)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -62,7 +62,7 @@ def setup_database_indexes():
         game_collection.create_index([("sport", 1)], background=True)
         game_collection.create_index([("date", 1)], background=True)
         game_collection.create_index([("gender", 1)], background=True)
-        game_collection.create_index([("location", 1)], background=True)
+        game_collection.create_index([("city", 1)], background=True)
 
         # Create compound indexes for common query combinations
         game_collection.create_index([("sport", 1), ("gender", 1)], background=True)

--- a/src/database.py
+++ b/src/database.py
@@ -62,6 +62,7 @@ def setup_database_indexes():
         game_collection.create_index([("sport", 1)], background=True)
         game_collection.create_index([("date", 1)], background=True)
         game_collection.create_index([("gender", 1)], background=True)
+        game_collection.create_index([("location", 1)], background=True)
 
         # Create compound indexes for common query combinations
         game_collection.create_index([("sport", 1), ("gender", 1)], background=True)

--- a/src/queries/game_query.py
+++ b/src/queries/game_query.py
@@ -1,6 +1,6 @@
 from bson import ObjectId
 from flask_jwt_extended import get_jwt_identity, jwt_required
-from graphene import ObjectType, String, Field, List, Int, DateTime
+from graphene import Boolean, ObjectType, String, Field, List, Int, DateTime
 from src.database import db
 from src.services.game_service import GameService
 from src.types import GameType
@@ -30,6 +30,7 @@ class GameQuery(ObjectType):
         GameType, sport=String(required=True), gender=String(required=True)
     )
     games_by_date = List(GameType, startDate=DateTime(required=True), endDate=DateTime(required=True))
+    games_by_location = List(GameType, onCampus=Boolean(required=True))
     my_favorited_games = List(GameType, description="Current user's favorited games (requires auth).")
 
     @jwt_required()
@@ -88,3 +89,10 @@ class GameQuery(ObjectType):
         Resolver for retrieving games by date.
         """
         return GameService.get_games_by_date(startDate, endDate)
+    
+    
+    def resolve_games_by_location(self, info, onCampus):
+        """
+        Resolver for retrieving games by location.
+        """
+        return GameService.get_games_by_location(onCampus)

--- a/src/repositories/game_repository.py
+++ b/src/repositories/game_repository.py
@@ -256,15 +256,10 @@ class GameRepository:
         """
         game_collection = db["game"]
 
-        CAMPUS_LOCATIONS = [
-            "Ithaca, NY",
-            "Lynah Rink"
-        ]
-
         if onCampus:
-            query = {"location": {"$in": CAMPUS_LOCATIONS}}
+            query = {"city": "Ithaca"}
         else:
-            query = {"location": {"$nin": CAMPUS_LOCATIONS}}
+            query = {"city": {"$ne": "Ithaca"}}
 
         games = game_collection.find(query)
 

--- a/src/repositories/game_repository.py
+++ b/src/repositories/game_repository.py
@@ -246,6 +246,29 @@ class GameRepository:
         
         games = game_collection.find(query)
         return [Game.from_dict(game) for game in games]
+    
+    @staticmethod
+    def find_by_location(onCampus):
+        """
+        Retrieve all games from the 'game' collection in MongoDB where
+        "onCampus" boolean indicates location is on campus (true) or 
+        off campus (false).
+        """
+        game_collection = db["game"]
+
+        CAMPUS_LOCATIONS = [
+            "Ithaca, NY",
+            "Lynah Rink"
+        ]
+
+        if onCampus:
+            query = {"location": {"$in": CAMPUS_LOCATIONS}}
+        else:
+            query = {"location": {"$nin": CAMPUS_LOCATIONS}}
+
+        games = game_collection.find(query)
+
+        return [Game.from_dict(game) for game in games]
 
     @staticmethod
     def find_by_ids(game_ids):

--- a/src/services/game_service.py
+++ b/src/services/game_service.py
@@ -121,6 +121,13 @@ class GameService:
         return GameRepository.find_by_date(startDate, endDate)
 
     @staticmethod
+    def get_games_by_location(onCampus):
+        """
+        Retrieves all games by their location.
+        """
+        return GameRepository.find_by_location(onCampus)
+
+    @staticmethod
     def get_tournament_games_by_sport_gender(sport, gender, after_date=None):
         """
         Find tournament games (with placeholder team names) for a specific sport and gender.


### PR DESCRIPTION
##Overview

Added support for filtering games by on-campus vs off-campus locations through a new GraphQL query. This allows clients to easily retrieve games based on whether they are played in Ithaca (on-campus) or elsewhere.

##Changes Made

Implemented a new repository method find_by_location(onCampus) that queries MongoDB using:

"city": "Ithaca" for on-campus games

"city": { "$ne": "Ithaca" } for off-campus games

##Test Coverage
Manual Testing, ran GraphQL queries in GraphiQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now filter games by location type—either on-campus or off-campus events—making it easier to discover games matching their geographic preferences.

* **Chores**
  * Enhanced database performance with indexing optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->